### PR TITLE
驼峰法转换规则调整

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.wangzaixiang"
 
 name := "scala-sql"
 
-version := "2.0.7-SNAPSHOT"
+version := "2.0.8-SNAPSHOT"
 
 scalaVersion := "2.12.4"
 

--- a/src/main/scala/wangzx/scala_commons/sql/package.scala
+++ b/src/main/scala/wangzx/scala_commons/sql/package.scala
@@ -333,7 +333,7 @@ package object sql {
           else {
             if(Character.isLowerCase(lastChar) && Character.isUpperCase(ch)) {
               sb.append('_')
-              sb.append(ch)
+              sb.append(ch.toLower)
             }
             else sb.append(ch)
           }


### PR DESCRIPTION
由于ShardingResultSet 和 jdbc里面的DruidPooledResultSet的 实现不一致 在运行到rs.get[T](underscoreName.get)时 需要underscoreName.get 必须和数据库字段保持一致。现在不符合驼峰法规则的字段都是通过和原数据库保持一致的写法能取得到，现在驼峰法的转换规则是 stockNo -> stock_No 需要调整为 stockNo -> stock_no